### PR TITLE
 이메일 중복 예외처리

### DIFF
--- a/src/main/java/backend/taskweaver/domain/member/controller/SignController.java
+++ b/src/main/java/backend/taskweaver/domain/member/controller/SignController.java
@@ -26,7 +26,7 @@ public class SignController {
     @PostMapping("/v1/auth/sign-up")
     public ResponseEntity<ApiResponse> signUp(@RequestBody SignUpRequest request) {
         ApiResponse ar = ApiResponse.builder()
-                .result(signService.registMember(request))
+                .result(signService.registerMember(request))
                 .resultCode(SuccessCode.INSERT_SUCCESS.getStatus())
                 .resultMsg(SuccessCode.INSERT_SUCCESS.getMessage())
                 .build();

--- a/src/main/java/backend/taskweaver/domain/member/entity/Member.java
+++ b/src/main/java/backend/taskweaver/domain/member/entity/Member.java
@@ -21,7 +21,8 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(nullable = false, length = 40)
+    // unique = true를 추가하여, 동일한 이메일을 가지고 가입하려고 할 때 DataIntegrityViolationException이 일어나게 한다.
+    @Column(nullable = false, length = 40, unique = true)
     private String email;
 
     @Column(nullable = false, length = 60)

--- a/src/main/java/backend/taskweaver/domain/member/service/SignService.java
+++ b/src/main/java/backend/taskweaver/domain/member/service/SignService.java
@@ -9,7 +9,9 @@ import backend.taskweaver.domain.member.entity.MemberRefreshToken;
 import backend.taskweaver.domain.member.entity.enums.LoginType;
 import backend.taskweaver.domain.member.repository.MemberRefreshTokenRepository;
 import backend.taskweaver.domain.member.repository.MemberRepository;
+import backend.taskweaver.global.code.ErrorCode;
 import backend.taskweaver.global.converter.MemberConverter;
+import backend.taskweaver.global.exception.handler.BusinessExceptionHandler;
 import backend.taskweaver.global.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -27,14 +29,13 @@ public class SignService {
 
 
     @Transactional
-    public SignUpResponse registMember(SignUpRequest request) {
-        Member member = memberRepository.save(MemberConverter.toMember(request, encoder));
+    public SignUpResponse registerMember(SignUpRequest request) {
         try {
-            memberRepository.flush();
+            Member member = memberRepository.saveAndFlush(MemberConverter.toMember(request, encoder));
+            return MemberConverter.toSignUpResponse(member);
         } catch (DataIntegrityViolationException e) {
-            throw new IllegalArgumentException("이미 사용중인 아이디입니다.");
+            throw new BusinessExceptionHandler(ErrorCode.DUPLICATED_EMAIL);
         }
-        return MemberConverter.toSignUpResponse(member);
     }
 
     //@Transactional(readOnly = true)

--- a/src/main/java/backend/taskweaver/global/code/ErrorCode.java
+++ b/src/main/java/backend/taskweaver/global/code/ErrorCode.java
@@ -82,7 +82,10 @@ public enum ErrorCode {
 
     // TEAM
     TEAM_NOT_FOUND(404, "T001", "Team Not Found"),
-    TEAM_MEMBER_NOT_FOUND(404, "T002", "Team member Not Found");
+    TEAM_MEMBER_NOT_FOUND(404, "T002", "Team member Not Found"),
+
+    // MEMBER
+    DUPLICATED_EMAIL(409, "M001", "Email is duplicated");
 
     ; // End
 


### PR DESCRIPTION
### 설명
저희 코드 보니까 이미 이메일 중복 예외처리 코드가 있더라고요.  DataIntegrityViolationException이 발생하면 예외를 던져주는 코드가 이미 있었습니다. 하지만 이게 작동하지 않아서 이걸 작동하게끔만 변경했습니다. 따로 예외처리 메서드를 만드는 게 좋지만, 어차피 이메일 인증으로 바꿀 것이라 우선은 이렇게만 변경했습니다.


### 변경 사항
1. DataIntegrityViolationException이 발생하려면 이메일 칼럼에 UNIQUE 제약 조건이 있어야 하는데, 우리가 이게 없었습니다. 멤버 엔티티 안 이메일 필드에 제약 조건 추가했습니다.
2. jpa 쓰기 지연 문제 때문에 멤버 저장할 때 메서드를 saveAndFlush()로 메서드를 변경했습니다.