### PR TITLE
Feat/#52 팀 리스트 전체 조회 기능 완료

### DIFF
--- a/src/main/java/backend/taskweaver/domain/team/controller/TeamController.java
+++ b/src/main/java/backend/taskweaver/domain/team/controller/TeamController.java
@@ -67,6 +67,18 @@ public class TeamController {
         return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
     }
 
+    // 팀 전체 조회
+    @Operation(summary =  "로그인한 유저의 팀 전체 조회")
+    @GetMapping("/teams")
+    public ResponseEntity<ApiResponse> AllTeam(@AuthenticationPrincipal User user) {
+        ApiResponse apiResponse = ApiResponse.builder()
+                .result(teamService.findTeamsByUserId(Long.parseLong(user.getUsername())))
+                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
+    }
+
     @Operation(summary =  "팀원 삭제")
     @PostMapping("/team/{teamId}/delete")
     public ResponseEntity<ApiResponse> deleteTeamMembers(@PathVariable Long teamId, @RequestBody TeamRequest.teamDeleteRequest request, @AuthenticationPrincipal User user) {

--- a/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
+++ b/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
@@ -87,5 +87,7 @@ public class TeamResponse {
     public static class AllTeamInfo {
         Long id;
         String name;
+        String myRole;
+        int totalMembers;
     }
 }

--- a/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
+++ b/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
@@ -89,5 +89,15 @@ public class TeamResponse {
         String name;
         String myRole;
         int totalMembers;
+        List<MemberInfo> members; // members 추가
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+        private Long id;
+        private String imageUrl;
     }
 }

--- a/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
+++ b/src/main/java/backend/taskweaver/domain/team/dto/TeamResponse.java
@@ -79,4 +79,13 @@ public class TeamResponse {
         @Schema(description = "삭제 원하는 id 리스트 형태로", example = "[1, 2, 3]")
         List<Long> memberId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AllTeamInfo {
+        Long id;
+        String name;
+    }
 }

--- a/src/main/java/backend/taskweaver/domain/team/entity/Team.java
+++ b/src/main/java/backend/taskweaver/domain/team/entity/Team.java
@@ -38,4 +38,6 @@ public class Team extends BaseEntity {
 
     private Long teamLeader;
 
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<TeamMember> teamMembers = new HashSet<>();
 }

--- a/src/main/java/backend/taskweaver/domain/team/entity/TeamMember.java
+++ b/src/main/java/backend/taskweaver/domain/team/entity/TeamMember.java
@@ -4,6 +4,7 @@ package backend.taskweaver.domain.team.entity;
 import backend.taskweaver.domain.BaseEntity;
 import backend.taskweaver.domain.member.entity.Member;
 import backend.taskweaver.domain.team.entity.enums.TeamRole;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -25,10 +26,12 @@ public class TeamMember extends BaseEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
 

--- a/src/main/java/backend/taskweaver/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/backend/taskweaver/domain/team/repository/TeamMemberRepository.java
@@ -21,4 +21,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByTeamAndMember(Team team, Member member);
 
     Optional<Object> findByTeamIdAndMemberId(Long teamId, Long user);
+
+    List<TeamMember> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/backend/taskweaver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/backend/taskweaver/domain/team/repository/TeamRepository.java
@@ -1,10 +1,14 @@
 package backend.taskweaver.domain.team.repository;
 
 import backend.taskweaver.domain.team.entity.Team;
+import backend.taskweaver.domain.team.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Object> findByIdAndTeamLeader(Long teamId, Long user);
+
+
 }

--- a/src/main/java/backend/taskweaver/domain/team/service/TeamService.java
+++ b/src/main/java/backend/taskweaver/domain/team/service/TeamService.java
@@ -2,8 +2,6 @@ package backend.taskweaver.domain.team.service;
 
 
 import backend.taskweaver.domain.team.dto.*;
-import backend.taskweaver.domain.team.entity.TeamMember;
-import org.springframework.security.core.userdetails.User;
 
 import java.util.List;
 
@@ -13,6 +11,8 @@ public interface TeamService {
     // 우선 팀 생성자 필드로만 추가
     public TeamResponse.teamCreateResult createTeam(TeamRequest.teamCreateRequest request, Long user);
     public TeamResponse.findTeamResult findTeam(Long id);
+
+    public List<TeamResponse.AllTeamInfo> findTeamsByUserId(Long userId);
     public TeamInviteRequest.EmailInviteRequest inviteEmail(TeamInviteRequest.EmailInviteRequest request);
 
     public TeamInviteResponse.InviteAnswerResult answerInvite(TeamInviteRequest.InviteAnswerRequest request, Long user);

--- a/src/main/java/backend/taskweaver/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/team/service/TeamServiceImpl.java
@@ -17,12 +17,11 @@ import backend.taskweaver.global.exception.handler.BusinessExceptionHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static backend.taskweaver.global.converter.TeamConverter.generateInviteLink;
 
@@ -74,6 +73,14 @@ public class TeamServiceImpl implements TeamService{
 
     public List<TeamMember> findAllTeamMemberWithTeam(Long teamId) {
         return teamMemberRepository.findAllByTeamId(teamId);
+    }
+
+
+    public List<TeamResponse.AllTeamInfo> findTeamsByUserId(Long userId) {
+        List<TeamMember> teamMembers = teamMemberRepository.findAllByMemberId(userId);
+        return teamMembers.stream()
+                .map(teamMember -> TeamConverter.toGetAllTeamResponse(teamMember.getTeam()))
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/backend/taskweaver/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/team/service/TeamServiceImpl.java
@@ -76,10 +76,20 @@ public class TeamServiceImpl implements TeamService{
     }
 
 
+
     public List<TeamResponse.AllTeamInfo> findTeamsByUserId(Long userId) {
         List<TeamMember> teamMembers = teamMemberRepository.findAllByMemberId(userId);
         return teamMembers.stream()
-                .map(teamMember -> TeamConverter.toGetAllTeamResponse(teamMember.getTeam()))
+                .map(teamMember -> {
+                    String myRole = teamMember.getRole().toString();
+                    int totalMembers = teamMember.getTeam().getTeamMembers().size(); // 전체 인원수 가져오기
+                    int adjustedTotalMembers = totalMembers - 3;
+                    return TeamConverter.toGetAllTeamResponse(
+                            teamMember.getTeam(),
+                            myRole,
+                            adjustedTotalMembers < 0 ? 0 : adjustedTotalMembers // 만약 음수라면 0을 반환
+                    );
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
@@ -41,10 +41,12 @@ public class TeamConverter {
         );
     }
 
-    public static TeamResponse.AllTeamInfo toGetAllTeamResponse(Team team) {
+    public static TeamResponse.AllTeamInfo toGetAllTeamResponse(Team team, String myRole, int totalMembers) {
         return new TeamResponse.AllTeamInfo(
                 team.getId(),
-                team.getName()
+                team.getName(),
+                myRole,
+                totalMembers
         );
     }
     public static TeamResponse.findTeamResult toGetTeamResponse(Team team, List<TeamMember> teamMembers) {

--- a/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
@@ -41,6 +41,12 @@ public class TeamConverter {
         );
     }
 
+    public static TeamResponse.AllTeamInfo toGetAllTeamResponse(Team team) {
+        return new TeamResponse.AllTeamInfo(
+                team.getId(),
+                team.getName()
+        );
+    }
     public static TeamResponse.findTeamResult toGetTeamResponse(Team team, List<TeamMember> teamMembers) {
         List<TeamResponse.TeamMemberInfo> memberInfos = teamMembers.stream()
                 .map(member -> new TeamResponse.TeamMemberInfo(

--- a/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/TeamConverter.java
@@ -41,14 +41,16 @@ public class TeamConverter {
         );
     }
 
-    public static TeamResponse.AllTeamInfo toGetAllTeamResponse(Team team, String myRole, int totalMembers) {
+    public static TeamResponse.AllTeamInfo toGetAllTeamResponse(Team team, String myRole, int totalMembers, List<TeamResponse.MemberInfo> members) {
         return new TeamResponse.AllTeamInfo(
                 team.getId(),
                 team.getName(),
                 myRole,
-                totalMembers
+                totalMembers,
+                members
         );
     }
+
     public static TeamResponse.findTeamResult toGetTeamResponse(Team team, List<TeamMember> teamMembers) {
         List<TeamResponse.TeamMemberInfo> memberInfos = teamMembers.stream()
                 .map(member -> new TeamResponse.TeamMemberInfo(


### PR DESCRIPTION
로그인한 유저가 들어있는 팀 리스트 전체 조회
- 팀 이름
- 본인 역할
- 팀원 정보(프로필 사진) 3개
- 추가 인원 수 

팀원 정보 출력 순서는 아직 확실하지 않아 최신순으로 설정
추가 인원 수는 해당 팀 전체 인원수 - 4(로그인한 유저 + 팀원 정보 뜨는 3명)로 출력