### PR TITLE
프로젝트 api들 수정 

### DIFF
--- a/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
+++ b/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
@@ -42,29 +42,29 @@ public class ProjectController {
                 .body(apiResponse);
     }
 
-    @GetMapping("/team/{teamId}/projects")
-    @Operation(summary = "프로젝트 전체 조회 메서드", description = "팀 내 모든 프로젝트를 조회하는 api입니다.")
-    public ResponseEntity<ApiResponse> getAllProject(@PathVariable @Parameter(description = "팀 ID") Long teamId) {
-        ApiResponse apiResponse = ApiResponse.<List<ProjectResponse>>builder()
-                .result(projectService.getAll(teamId))
-                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
-                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
-                .build();
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(apiResponse);
-    }
-
-    @GetMapping("/project/{projectId}")
-    @Operation(summary = "프로젝트 상세 조회 메서드", description = "한 프로젝트에 대해 상세 조회하는 api입니다.")
-    public ResponseEntity<ApiResponse> getOneProject(@PathVariable @Parameter(description = "프로젝트 ID")Long projectId) {
-        ApiResponse apiResponse = ApiResponse.<ProjectResponse>builder()
-                .result(projectService.getOne(projectId))
-                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
-                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
-                .build();
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(apiResponse);
-    }
+//    @GetMapping("/team/{teamId}/projects")
+//    @Operation(summary = "프로젝트 전체 조회 메서드", description = "팀 내 모든 프로젝트를 조회하는 api입니다.")
+//    public ResponseEntity<ApiResponse> getAllProject(@PathVariable @Parameter(description = "팀 ID") Long teamId) {
+//        ApiResponse apiResponse = ApiResponse.<List<ProjectResponse>>builder()
+//                .result(projectService.getAll(teamId))
+//                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+//                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+//                .build();
+//        return ResponseEntity.status(HttpStatus.OK)
+//                .body(apiResponse);
+//    }
+//
+//    @GetMapping("/project/{projectId}")
+//    @Operation(summary = "프로젝트 상세 조회 메서드", description = "한 프로젝트에 대해 상세 조회하는 api입니다.")
+//    public ResponseEntity<ApiResponse> getOneProject(@PathVariable @Parameter(description = "프로젝트 ID")Long projectId) {
+//        ApiResponse apiResponse = ApiResponse.<ProjectResponse>builder()
+//                .result(projectService.getOne(projectId))
+//                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+//                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+//                .build();
+//        return ResponseEntity.status(HttpStatus.OK)
+//                .body(apiResponse);
+//    }
 
     @PatchMapping("/project/{projectId}/state")
     @Operation(summary = "프로젝트 상태 변경 메서드", description = "프로젝트의 상태를 변경하는 api입니다.")

--- a/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
+++ b/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package backend.taskweaver.domain.project.controller;
 
+import backend.taskweaver.domain.project.dto.ProjectMemberResponse;
 import backend.taskweaver.domain.project.dto.ProjectRequest;
 import backend.taskweaver.domain.project.dto.ProjectResponse;
 import backend.taskweaver.domain.project.dto.UpdateStateRequest;
@@ -65,6 +66,18 @@ public class ProjectController {
 //        return ResponseEntity.status(HttpStatus.OK)
 //                .body(apiResponse);
 //    }
+
+    @GetMapping("/project/{projectId}/members")
+    @Operation(summary = "프로젝트 멤버 전체 조회 메서드", description = "프로젝트 내의 모든 프로젝트원들을 조회하는 api입니다.")
+    public ResponseEntity<ApiResponse> getAllProjectMembers(@PathVariable @Parameter(description = "프로젝트 ID") Long projectId) {
+        ApiResponse apiResponse = ApiResponse.<ProjectMemberResponse>builder()
+                .result(projectService.getAllProjectMembers(projectId))
+                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(apiResponse);
+    }
 
     @PatchMapping("/project/{projectId}/state")
     @Operation(summary = "프로젝트 상태 변경 메서드", description = "프로젝트의 상태를 변경하는 api입니다.")

--- a/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
+++ b/src/main/java/backend/taskweaver/domain/project/controller/ProjectController.java
@@ -43,29 +43,29 @@ public class ProjectController {
                 .body(apiResponse);
     }
 
-//    @GetMapping("/team/{teamId}/projects")
-//    @Operation(summary = "프로젝트 전체 조회 메서드", description = "팀 내 모든 프로젝트를 조회하는 api입니다.")
-//    public ResponseEntity<ApiResponse> getAllProject(@PathVariable @Parameter(description = "팀 ID") Long teamId) {
-//        ApiResponse apiResponse = ApiResponse.<List<ProjectResponse>>builder()
-//                .result(projectService.getAll(teamId))
-//                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
-//                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
-//                .build();
-//        return ResponseEntity.status(HttpStatus.OK)
-//                .body(apiResponse);
-//    }
-//
-//    @GetMapping("/project/{projectId}")
-//    @Operation(summary = "프로젝트 상세 조회 메서드", description = "한 프로젝트에 대해 상세 조회하는 api입니다.")
-//    public ResponseEntity<ApiResponse> getOneProject(@PathVariable @Parameter(description = "프로젝트 ID")Long projectId) {
-//        ApiResponse apiResponse = ApiResponse.<ProjectResponse>builder()
-//                .result(projectService.getOne(projectId))
-//                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
-//                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
-//                .build();
-//        return ResponseEntity.status(HttpStatus.OK)
-//                .body(apiResponse);
-//    }
+    @GetMapping("/team/{teamId}/projects")
+    @Operation(summary = "프로젝트 전체 조회 메서드", description = "팀 내 모든 프로젝트를 조회하는 api입니다.")
+    public ResponseEntity<ApiResponse> getAllProject(@PathVariable @Parameter(description = "팀 ID") Long teamId) {
+        ApiResponse apiResponse = ApiResponse.<List<ProjectResponse>>builder()
+                .result(projectService.getAll(teamId))
+                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(apiResponse);
+    }
+
+    @GetMapping("/project/{projectId}")
+    @Operation(summary = "프로젝트 상세 조회 메서드", description = "한 프로젝트에 대해 상세 조회하는 api입니다.")
+    public ResponseEntity<ApiResponse> getOneProject(@PathVariable @Parameter(description = "프로젝트 ID")Long projectId) {
+        ApiResponse apiResponse = ApiResponse.<ProjectResponse>builder()
+                .result(projectService.getOne(projectId))
+                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+                .resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(apiResponse);
+    }
 
     @GetMapping("/project/{projectId}/members")
     @Operation(summary = "프로젝트 멤버 전체 조회 메서드", description = "프로젝트 내의 모든 프로젝트원들을 조회하는 api입니다.")

--- a/src/main/java/backend/taskweaver/domain/project/dto/ProjectMemberResponse.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/ProjectMemberResponse.java
@@ -1,0 +1,20 @@
+package backend.taskweaver.domain.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "프로젝트 멤버 응답 DTO")
+public record ProjectMemberResponse(
+        List<MemberList> memberList
+) {
+    public record MemberList (
+            @Schema(description = "멤버 ID", example = "1")
+            Long id,
+            @Schema(description = "이미지 URL", example = "https://taskweaverBucket.s3.ap-northeast-2.amazonaws.com/123.jpg")
+            String imageUrl,
+            @Schema(description = "멤버 닉네임", example = "윤채은")
+            String nickname
+    ) {
+    }
+}

--- a/src/main/java/backend/taskweaver/domain/project/dto/ProjectRequest.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/ProjectRequest.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 @Schema(description = "프로젝트 요청 DTO")
 public record ProjectRequest(
         @NotBlank
@@ -16,6 +18,10 @@ public record ProjectRequest(
 
         @NotNull
         @Schema(description = "프로젝트 담당자 ID", example = "1")
-        Long managerId
+        Long managerId,
+
+        @NotNull
+        @Schema(description = "프로젝트 멤버 ID", example = "[1, 2, 3]")
+        List<Long> memberIdList
 ) {
 }

--- a/src/main/java/backend/taskweaver/domain/project/dto/ProjectRequest.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/ProjectRequest.java
@@ -1,15 +1,16 @@
 package backend.taskweaver.domain.project.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "프로젝트 요청 DTO")
 public record ProjectRequest(
-        @NotNull
+        @NotBlank
         @Schema(description = "프로젝트 제목", example = "oo과목 중간 대체 프로젝트")
         String name,
 
-        @NotNull
+        @NotBlank
         @Schema(description = "프로젝트 설명", example = "이 프로젝트는 oo과목을 위한 프로젝트입니다.")
         String description,
 

--- a/src/main/java/backend/taskweaver/domain/project/dto/ProjectResponse.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/ProjectResponse.java
@@ -3,6 +3,8 @@ package backend.taskweaver.domain.project.dto;
 import backend.taskweaver.domain.project.entity.enums.ProjectStateName;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 @Schema(description = "프로젝트 응답 DTO")
 public record ProjectResponse(
         @Schema(description = "프로젝트 ID", example = "1")
@@ -18,6 +20,9 @@ public record ProjectResponse(
         Long managerId,
 
         @Schema(description = "프로젝트 상태", example = "ON_PROGRESS")
-        ProjectStateName projectState
+        ProjectStateName projectState,
+
+        @Schema(description = "프로젝트 생성 날짜", example = "2024-04-04T11:04:54.1920")
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/backend/taskweaver/domain/project/dto/ProjectResponse.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/ProjectResponse.java
@@ -4,6 +4,7 @@ import backend.taskweaver.domain.project.entity.enums.ProjectStateName;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "프로젝트 응답 DTO")
 public record ProjectResponse(
@@ -18,6 +19,9 @@ public record ProjectResponse(
 
         @Schema(description = "프로젝트 담당자 ID", example = "1")
         Long managerId,
+
+        @Schema(description = "프로젝트 멤버들 ID", example = "[1, 2, 3, 4]")
+        List<Long> memberId,
 
         @Schema(description = "프로젝트 상태", example = "ON_PROGRESS")
         ProjectStateName projectState,

--- a/src/main/java/backend/taskweaver/domain/project/dto/UpdateStateRequest.java
+++ b/src/main/java/backend/taskweaver/domain/project/dto/UpdateStateRequest.java
@@ -1,11 +1,11 @@
 package backend.taskweaver.domain.project.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "프로젝트 상태 변경 요청 DTO")
 public record UpdateStateRequest(
-        @NotNull
+        @NotBlank
         @Schema(description = "변경하고 싶은 프로젝트 상태", example = "ON_PROGRESS")
         String projectState
 ) {

--- a/src/main/java/backend/taskweaver/domain/project/entity/Project.java
+++ b/src/main/java/backend/taskweaver/domain/project/entity/Project.java
@@ -53,6 +53,5 @@ public class Project extends BaseEntity {
     public void updateProject(ProjectRequest request) {
         this.description = request.description();
         this.name = request.name();
-        setManagerId(request.managerId());
     }
 }

--- a/src/main/java/backend/taskweaver/domain/project/entity/Project.java
+++ b/src/main/java/backend/taskweaver/domain/project/entity/Project.java
@@ -53,5 +53,6 @@ public class Project extends BaseEntity {
     public void updateProject(ProjectRequest request) {
         this.description = request.description();
         this.name = request.name();
+        this.managerId = request.managerId();
     }
 }

--- a/src/main/java/backend/taskweaver/domain/project/entity/ProjectMember.java
+++ b/src/main/java/backend/taskweaver/domain/project/entity/ProjectMember.java
@@ -2,11 +2,8 @@ package backend.taskweaver.domain.project.entity;
 
 import backend.taskweaver.domain.BaseEntity;
 import backend.taskweaver.domain.member.entity.Member;
-import backend.taskweaver.domain.project.entity.enums.ProjectRole;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "project_member")
@@ -20,10 +17,6 @@ public class ProjectMember extends BaseEntity {
     @Column(name = "project_member_id")
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "project_role", nullable = false)
-    private ProjectRole role;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
@@ -31,8 +24,4 @@ public class ProjectMember extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    public void changeRole(ProjectRole role) {
-        this.role = role;
-    }
 }

--- a/src/main/java/backend/taskweaver/domain/project/entity/enums/ProjectRole.java
+++ b/src/main/java/backend/taskweaver/domain/project/entity/enums/ProjectRole.java
@@ -1,5 +1,0 @@
-package backend.taskweaver.domain.project.entity.enums;
-
-public enum ProjectRole {
-    MANAGER, NON_MANAGER
-}

--- a/src/main/java/backend/taskweaver/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/backend/taskweaver/domain/project/repository/ProjectMemberRepository.java
@@ -10,6 +10,6 @@ import java.util.List;
 
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
-    Optional<ProjectMember> findByMemberIdAndProjectId(Long memberId, Long projectId);
     List<ProjectMember> findByProject(Project project);
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package backend.taskweaver.domain.project.service;
 
+import backend.taskweaver.domain.project.dto.ProjectMemberResponse;
 import backend.taskweaver.domain.project.dto.ProjectRequest;
 import backend.taskweaver.domain.project.dto.ProjectResponse;
 import backend.taskweaver.domain.project.dto.UpdateStateRequest;
@@ -12,6 +13,7 @@ public interface ProjectService{
     void createProjectMember(Project project, ProjectRequest request);
     //List<ProjectResponse> getAll(Long teamId);
     //ProjectResponse getOne(Long projectId);
+    ProjectMemberResponse getAllProjectMembers(Long projectId);
     void updateState(Long projectId, UpdateStateRequest request, Long memberId);
     void updateProject(Long projectId, ProjectRequest request, Long memberId);
     void delete(Long projectId, Long memberId);

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
@@ -11,8 +11,8 @@ import java.util.List;
 public interface ProjectService{
     ProjectResponse createProject(ProjectRequest request, Long teamId);
     void createProjectMember(Project project, ProjectRequest request);
-    //List<ProjectResponse> getAll(Long teamId);
-    //ProjectResponse getOne(Long projectId);
+    List<ProjectResponse> getAll(Long teamId);
+    ProjectResponse getOne(Long projectId);
     ProjectMemberResponse getAllProjectMembers(Long projectId);
     void updateState(Long projectId, UpdateStateRequest request, Long memberId);
     void updateProject(Long projectId, ProjectRequest request, Long memberId);

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectService.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 public interface ProjectService{
     ProjectResponse createProject(ProjectRequest request, Long teamId);
-    void createProjectMember(Project project, Long managerId);
-    List<ProjectResponse> getAll(Long teamId);
-    ProjectResponse getOne(Long projectId);
+    void createProjectMember(Project project, ProjectRequest request);
+    //List<ProjectResponse> getAll(Long teamId);
+    //ProjectResponse getOne(Long projectId);
     void updateState(Long projectId, UpdateStateRequest request, Long memberId);
     void updateProject(Long projectId, ProjectRequest request, Long memberId);
     void delete(Long projectId, Long memberId);

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -2,6 +2,7 @@ package backend.taskweaver.domain.project.service;
 
 import backend.taskweaver.domain.member.entity.Member;
 import backend.taskweaver.domain.member.repository.MemberRepository;
+import backend.taskweaver.domain.project.dto.ProjectMemberResponse;
 import backend.taskweaver.domain.project.dto.ProjectRequest;
 import backend.taskweaver.domain.project.dto.ProjectResponse;
 import backend.taskweaver.domain.project.dto.UpdateStateRequest;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -102,6 +104,16 @@ public class ProjectServiceImpl implements ProjectService {
 //                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
 //        return ProjectConverter.toProjectResponse(project, project.getProjectState());
 //    }
+
+
+    @Override
+    @Transactional
+    public ProjectMemberResponse getAllProjectMembers(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
+        List<ProjectMember> projectMembers = projectMemberRepository.findByProject(project);
+        return ProjectConverter.toProjectMemberResponse(projectMembers);
+    }
 
     public void delete(Long projectId, Long memberId) {
         Project project = projectRepository.findById(projectId)

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -150,15 +150,15 @@ public class ProjectServiceImpl implements ProjectService {
         // 지금 로그인한 사용자가 매니저인지 확인한다. 아니면 에러를 던진다.
         checkIfIsManager(project.getManagerId(), memberId);
 
-        // 이미 담당자인 사람을 선택하지 않았을 경우
+        // 담당자가 변경됐을 경우
         if (!request.managerId().equals(project.getManagerId())) {
             changeRole(project.getManagerId(), projectId, ProjectRole.NON_MANAGER); // 기존 매니저의 권한을 없앤다.
-            changeRole(request.managerId(), projectId, ProjectRole.MANAGER); // 새로운 매니저로 임명한다!
+            changeRole(request.managerId(), projectId, ProjectRole.MANAGER); // 새로운 매니저를 임명한다!
+            project.setManagerId(request.managerId());
             project.updateProject(request);
-
-            // 이미 담당자인 사람을 선택했을 경우
+        // 변경되지 않았을 경우
         } else {
-            throw new BusinessExceptionHandler(ErrorCode.SAME_PROJECT_MANAGER);
+            project.updateProject(request);
         }
     }
 

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -85,10 +85,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public void updateProject(Long projectId, ProjectRequest request, Long memberId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
-
-        // 지금 로그인한 사용자가 매니저인지 확인하고 아니면 에러를 던진다.
+        Project project = validateProject(projectId);
         checkIfIsManager(project.getManagerId(), memberId);
 
         project.updateProject(request);
@@ -108,8 +105,7 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public ProjectResponse getOne(Long projectId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
+        Project project = validateProject(projectId);
         List<ProjectMember> projectMembers = projectMemberRepository.findByProject(project);
         List<Long> memberIdList  = projectMembers.stream()
                 .map(projectMember -> projectMember.getMember().getId())
@@ -120,8 +116,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public ProjectMemberResponse getAllProjectMembers(Long projectId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
+        Project project = validateProject(projectId);
         List<ProjectMember> projectMembers = projectMemberRepository.findByProject(project);
         return ProjectConverter.toProjectMemberResponse(projectMembers);
     }
@@ -129,10 +124,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public void delete(Long projectId, Long memberId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
-
-        // 지금 로그인한 사용자가 매니저인지 확인하고 아니면 에러를 던진다.
+        Project project = validateProject(projectId);
         checkIfIsManager(project.getManagerId(), memberId);
 
         // project members 삭제
@@ -151,10 +143,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public void updateState(Long projectId, UpdateStateRequest request, Long memberId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
-
-        // 지금 로그인한 사용자가 매니저인지 확인하고 아니면 에러를 던진다.
+        Project project = validateProject(projectId);
         checkIfIsManager(project.getManagerId(), memberId);
 
         ProjectStateName foundState = Arrays.stream(ProjectStateName.values())
@@ -166,10 +155,14 @@ public class ProjectServiceImpl implements ProjectService {
         projectState.changeProjectState(foundState);
     }
 
-
     private void checkIfIsManager(Long projectManagerId, Long memberId) {
         if (!projectManagerId.equals(memberId)) {
             throw new BusinessExceptionHandler(ErrorCode.NOT_PROJECT_MANAGER);
         }
+    }
+
+    private Project validateProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
     }
 }

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -80,6 +80,20 @@ public class ProjectServiceImpl implements ProjectService {
         projectMemberRepository.saveAll(projectMembers);
     }
 
+    @Override
+    @Transactional
+    public void updateProject(Long projectId, ProjectRequest request, Long memberId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.PROJECT_NOT_FOUND));
+
+        // 지금 로그인한 사용자가 매니저인지 확인한다. 아니면 에러를 던진다.
+        checkIfIsManager(project.getManagerId(), memberId);
+
+        project.updateProject(request);
+        projectMemberRepository.deleteAllByProject(project);
+        createProjectMember(project, request);
+    }
+
 //    @Override
 //    @Transactional(readOnly = true)
 //    public List<ProjectResponse> getAll(Long teamId) {

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -58,6 +59,7 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public void createProjectMember(Project project, ProjectRequest request) {
+        List<ProjectMember> projectMembers = new ArrayList<>();
         request.memberIdList().forEach(memberId -> {
             // 해당 회원이 존재하는지 확인
             Member member = memberRepository.findById(memberId)
@@ -68,15 +70,15 @@ public class ProjectServiceImpl implements ProjectService {
                     .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.MEMBER_NOT_BELONG_TO_TEAM));
 
             ProjectMember projectMember = ProjectConverter.toProjectMember(project, member);
-            projectMemberRepository.save(projectMember);
+            projectMembers.add(projectMember);
 
-            // 매니저면 매니저 ID 거장
+            // 매니저면 매니저 ID 설정
             if (memberId.equals(request.managerId())) {
                 project.setManagerId(request.managerId());
             }
         });
+        projectMemberRepository.saveAll(projectMembers);
     }
-
 
 //    @Override
 //    @Transactional(readOnly = true)

--- a/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/backend/taskweaver/domain/project/service/ProjectServiceImpl.java
@@ -101,9 +101,8 @@ public class ProjectServiceImpl implements ProjectService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessExceptionHandler(ErrorCode.TEAM_NOT_FOUND));
         List<Project> projects = projectRepository.findAllByTeam(team);
-
         return projects.stream()
-                .map(project -> ProjectConverter.toProjectResponse(project, project.getProjectState()))
+                .map(project -> ProjectConverter.toProjectResponse(project, null))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/backend/taskweaver/domain/task/entity/TaskMember.java
+++ b/src/main/java/backend/taskweaver/domain/task/entity/TaskMember.java
@@ -2,8 +2,6 @@ package backend.taskweaver.domain.task.entity;
 
 import backend.taskweaver.domain.BaseEntity;
 import backend.taskweaver.domain.member.entity.Member;
-import backend.taskweaver.domain.project.entity.Project;
-import backend.taskweaver.domain.project.entity.enums.ProjectRole;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/backend/taskweaver/global/code/ErrorCode.java
+++ b/src/main/java/backend/taskweaver/global/code/ErrorCode.java
@@ -87,7 +87,7 @@ public enum ErrorCode {
     NOT_PROJECT_MANAGER(403, "P003", "Only Project manager can do this work."),
     PROJECT_STATE_NOT_FOUND(404, "POO4", "Project State Not Found"),
     PROJECT_MEMBER_NOT_FOUND(404, "P005", "Project Member Not Found"),
-    MANAGER_ID_NOT_IN_MEMBER_ID_LIST(400, "P004", "MemberIdList doesn't include managerId"),
+    MANAGER_ID_NOT_IN_MEMBER_ID_LIST(400, "P004", "Member id list doesn't include manager id. Include manager id in member id list"),
 
     // TEAM
     TEAM_NOT_FOUND(404, "T001", "Team Not Found"),

--- a/src/main/java/backend/taskweaver/global/code/ErrorCode.java
+++ b/src/main/java/backend/taskweaver/global/code/ErrorCode.java
@@ -87,7 +87,7 @@ public enum ErrorCode {
     NOT_PROJECT_MANAGER(403, "P003", "Only Project manager can do this work."),
     PROJECT_STATE_NOT_FOUND(404, "POO4", "Project State Not Found"),
     PROJECT_MEMBER_NOT_FOUND(404, "P005", "Project Member Not Found"),
-    SAME_PROJECT_MANAGER(400, "P006", "The selected member is already a manager."),
+    MANAGER_ID_NOT_IN_MEMBER_ID_LIST(400, "P004", "MemberIdList doesn't include managerId"),
 
     // TEAM
     TEAM_NOT_FOUND(404, "T001", "Team Not Found"),

--- a/src/main/java/backend/taskweaver/global/code/ErrorCode.java
+++ b/src/main/java/backend/taskweaver/global/code/ErrorCode.java
@@ -82,7 +82,7 @@ public enum ErrorCode {
     DELETE_ERROR(500, "9999", "Delete Transaction Error Exception"),
 
     // PROJECT
-    BELONG_TO_WRONG_TEAM_ERROR(400, "P001", "This Manager doesn't belong to this team"),
+    MEMBER_NOT_BELONG_TO_TEAM(400, "P001", "Member doesn't belong to this team"),
     PROJECT_NOT_FOUND(404, "P002", "Project Not Found"),
     NOT_PROJECT_MANAGER(403, "P003", "Only Project manager can do this work."),
     PROJECT_STATE_NOT_FOUND(404, "POO4", "Project State Not Found"),

--- a/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
@@ -10,6 +10,8 @@ import backend.taskweaver.domain.project.entity.enums.ProjectRole;
 import backend.taskweaver.domain.project.entity.enums.ProjectStateName;
 import backend.taskweaver.domain.team.entity.Team;
 
+import java.util.List;
+
 public class ProjectConverter {
 
     public static Project toProject(ProjectRequest request, Team team, ProjectState state) {
@@ -27,13 +29,14 @@ public class ProjectConverter {
                 .build();
     }
 
-    public static ProjectResponse toProjectResponse(Project project, ProjectState state) {
+    public static ProjectResponse toProjectResponse(Project project, List<Long> memberIdList) {
         return new ProjectResponse(
                 project.getId(),
                 project.getName(),
                 project.getDescription(),
                 project.getManagerId(),
-                state.getStateName(),
+                memberIdList,
+                project.getProjectState().getStateName(),
                 project.getCreatedAt()
         );
     }

--- a/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
@@ -7,7 +7,6 @@ import backend.taskweaver.domain.project.dto.ProjectResponse;
 import backend.taskweaver.domain.project.entity.Project;
 import backend.taskweaver.domain.project.entity.ProjectMember;
 import backend.taskweaver.domain.project.entity.ProjectState;
-import backend.taskweaver.domain.project.entity.enums.ProjectRole;
 import backend.taskweaver.domain.project.entity.enums.ProjectStateName;
 import backend.taskweaver.domain.team.entity.Team;
 
@@ -53,9 +52,8 @@ public class ProjectConverter {
         return new ProjectMemberResponse(memberList);
     }
 
-    public static ProjectMember toProjectMember(Project project, Member member, ProjectRole role) {
+    public static ProjectMember toProjectMember(Project project, Member member) {
         return ProjectMember.builder()
-                .role(role)
                 .member(member)
                 .project(project)
                 .build();

--- a/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
@@ -33,7 +33,8 @@ public class ProjectConverter {
                 project.getName(),
                 project.getDescription(),
                 project.getManagerId(),
-                state.getStateName()
+                state.getStateName(),
+                project.getCreatedAt()
         );
     }
 

--- a/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
+++ b/src/main/java/backend/taskweaver/global/converter/ProjectConverter.java
@@ -1,6 +1,7 @@
 package backend.taskweaver.global.converter;
 
 import backend.taskweaver.domain.member.entity.Member;
+import backend.taskweaver.domain.project.dto.ProjectMemberResponse;
 import backend.taskweaver.domain.project.dto.ProjectRequest;
 import backend.taskweaver.domain.project.dto.ProjectResponse;
 import backend.taskweaver.domain.project.entity.Project;
@@ -11,6 +12,7 @@ import backend.taskweaver.domain.project.entity.enums.ProjectStateName;
 import backend.taskweaver.domain.team.entity.Team;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ProjectConverter {
 
@@ -39,6 +41,16 @@ public class ProjectConverter {
                 project.getProjectState().getStateName(),
                 project.getCreatedAt()
         );
+    }
+
+    public static ProjectMemberResponse toProjectMemberResponse(List<ProjectMember> projectMembers) {
+        List<ProjectMemberResponse.MemberList> memberList = projectMembers.stream()
+                .map(projectMember -> new ProjectMemberResponse.MemberList(
+                        projectMember.getMember().getId(),
+                        projectMember.getMember().getImageUrl(),
+                        projectMember.getMember().getNickname()))
+                .collect(Collectors.toList());
+        return new ProjectMemberResponse(memberList);
     }
 
     public static ProjectMember toProjectMember(Project project, Member member, ProjectRole role) {


### PR DESCRIPTION
- NotNull을 @notblank로 수정
- 프로젝트 생성 api response에 생성날짜 전달해주기
- 프로젝트 수정 api에 같은 담당자 선택하면 에러내는 거 삭제하기

- JPA 메서드 save() -> saveAll()

- 몇몇 validation 메서드 분리

- 프로젝트 멤버 저장시 예외처리 추가
- 프로젝트의 모든 api 대폭 수정 - 프로젝트 멤버 부분
- 프로젝트 멤버 조회 api 만들기


