### PR TITLE
토큰 안 줘도 에러가 나지 않는 버그 해결

### DIFF
--- a/src/main/java/backend/taskweaver/global/code/ErrorCode.java
+++ b/src/main/java/backend/taskweaver/global/code/ErrorCode.java
@@ -66,8 +66,8 @@ public enum ErrorCode {
     // 지원하지 않는 JWT 토큰일 때 발생
     UNSUPPORTED_JWT_TOKEN(400,"G017", "The provided JWT token is not supported"),
 
-    // 토큰 클레임이 비어있을 때 발생
-    // TOKEN_CLAIM_EMPTY(400,"G016", "JWT claim is empty"),
+    // 토큰이 없을 때 발생
+    TOKEN_MISSING_ERROR(401, "G018", "Token is missing."),
 
     /**
      * ******************************* Custom Error CodeList ***************************************

--- a/src/main/java/backend/taskweaver/global/config/SecurityConfig.java
+++ b/src/main/java/backend/taskweaver/global/config/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final String[] allowedUrls = {"/", "/swagger-ui/**", "/v3/**", "/sign-up", "/sign-in", "/get-member-info"};
+    private final String[] allowedUrls = {"/", "/swagger-ui/**", "/v3/**", "/v1/auth/sign-in", "/v1/auth/sign-in", "/v1/user"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/backend/taskweaver/global/exception/handler/JwtTokenException.java
+++ b/src/main/java/backend/taskweaver/global/exception/handler/JwtTokenException.java
@@ -3,18 +3,18 @@ package backend.taskweaver.global.exception.handler;
 import backend.taskweaver.global.code.ErrorCode;
 import lombok.Builder;
 
-public class JwtTokenHandler extends RuntimeException {
+public class JwtTokenException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
     @Builder
-    public JwtTokenHandler(String message, ErrorCode errorCode) {
+    public JwtTokenException(String message, ErrorCode errorCode) {
         super(message);
         this.errorCode = errorCode;
     }
 
     @Builder
-    public JwtTokenHandler(ErrorCode errorCode) {
+    public JwtTokenException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/backend/taskweaver/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/backend/taskweaver/global/security/CustomAuthenticationEntryPoint.java
@@ -29,9 +29,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             setResponse(response, ErrorCode.UNSUPPORTED_JWT_TOKEN);
         } else if (exception.equals(ErrorCode.USER_AUTH_ERROR.getMessage())) {
             setResponse(response, ErrorCode.USER_AUTH_ERROR);
+        } else if(exception.equals(ErrorCode.TOKEN_MISSING_ERROR.getMessage())) {
+            setResponse(response, ErrorCode.TOKEN_MISSING_ERROR);
         }
-//        else if (exception.equals(ErrorCode.TOKEN_CLAIM_EMPTY.getMessage())) {
-//            setResponse(response, ErrorCode.TOKEN_CLAIM_EMPTY);
     }
 
     private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {

--- a/src/main/java/backend/taskweaver/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/backend/taskweaver/global/security/JwtAuthenticationFilter.java
@@ -53,9 +53,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             request.setAttribute("exception", ErrorCode.UNSUPPORTED_JWT_TOKEN.getMessage());
         } catch (AuthenticationException | NullPointerException e) {
             request.setAttribute("exception", ErrorCode.USER_AUTH_ERROR.getMessage());
+        } catch (JwtTokenHandler e) {
+            request.setAttribute("exception", ErrorCode.TOKEN_MISSING_ERROR.getMessage());
         }
-//        catch (IllegalArgumentException e) {
-//            request.setAttribute("exception", ErrorCode.TOKEN_CLAIM_EMPTY.getMessage());
 
         filterChain.doFilter(request, response);
     }
@@ -71,13 +71,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String[] split = Optional.ofNullable(token)
                 .filter(subject -> subject.length() >= 10)
                 .map(tokenProvider::validateTokenAndGetSubject)
-                .orElse("anonymous:anonymous")
+                .orElseThrow(()->new JwtTokenHandler(ErrorCode.TOKEN_MISSING_ERROR))
                 .split(":");
         System.out.println(split[0]);
         System.out.println(split[1]);
 
         return new User(split[0], "", List.of(new SimpleGrantedAuthority(split[1])));
     }
+
 
     private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response, Exception exception) {
         try {

--- a/src/main/java/backend/taskweaver/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/backend/taskweaver/global/security/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package backend.taskweaver.global.security;
 
 import backend.taskweaver.global.code.ErrorCode;
-import backend.taskweaver.global.exception.handler.JwtTokenHandler;
+import backend.taskweaver.global.exception.handler.JwtTokenException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -53,7 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             request.setAttribute("exception", ErrorCode.UNSUPPORTED_JWT_TOKEN.getMessage());
         } catch (AuthenticationException | NullPointerException e) {
             request.setAttribute("exception", ErrorCode.USER_AUTH_ERROR.getMessage());
-        } catch (JwtTokenHandler e) {
+        } catch (JwtTokenException e) {
             request.setAttribute("exception", ErrorCode.TOKEN_MISSING_ERROR.getMessage());
         }
 
@@ -71,7 +71,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String[] split = Optional.ofNullable(token)
                 .filter(subject -> subject.length() >= 10)
                 .map(tokenProvider::validateTokenAndGetSubject)
-                .orElseThrow(()->new JwtTokenHandler(ErrorCode.TOKEN_MISSING_ERROR))
+                .orElseThrow(()->new JwtTokenException(ErrorCode.TOKEN_MISSING_ERROR))
                 .split(":");
         System.out.println(split[0]);
         System.out.println(split[1]);


### PR DESCRIPTION
- 인증이 필수인 api임에도 불구하고 토큰 안 줘도 에러가 나지 않았습니다. 이 버그를 해결했습니다.
- 로그인한 사용자를 토큰으로 가져올 때, 토큰을 주지 않으면 뜨는 500 서버 에러가 떴습니다. 이걸 401 에러로 따로 잡아주고 오류 메세지도 변경했습니다.